### PR TITLE
bug internal: Fixing test failure for list_replicas; Fix #28

### DIFF
--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -93,11 +93,9 @@ def parse_expression(expression, filter=None, session=None):
         for rse in list(result_tuple[0]):
             result.append(result_tuple[1][rse])
         # Don't cache the result if we only specified vo
-        vo_pattern = r'vo=[a-zA-Z0-9]+'
+        vo_pattern = r'^vo=[a-zA-Z0-9]+$'
         vo_match = re.search(vo_pattern, expression)
         if vo_match is None:
-            REGION.set(sha256(expression.encode()).hexdigest(), result)
-        elif expression[0:vo_match.span()[0]] + expression[vo_match.span()[1]:]:
             REGION.set(sha256(expression.encode()).hexdigest(), result)
 
     if not result:

--- a/lib/rucio/core/rse_expression_parser.py
+++ b/lib/rucio/core/rse_expression_parser.py
@@ -20,6 +20,7 @@
 # - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2018-2019
 # - Brandon White, <bjwhite@fnal.gov>, 2019
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -91,7 +92,13 @@ def parse_expression(expression, filter=None, session=None):
         result = []
         for rse in list(result_tuple[0]):
             result.append(result_tuple[1][rse])
-        REGION.set(sha256(expression.encode()).hexdigest(), result)
+        # Don't cache the result if we only specified vo
+        vo_pattern = r'vo=[a-zA-Z0-9]+'
+        vo_match = re.search(vo_pattern, expression)
+        if vo_match is None:
+            REGION.set(sha256(expression.encode()).hexdigest(), result)
+        elif expression[0:vo_match.span()[0]] + expression[vo_match.span()[1]:]:
+            REGION.set(sha256(expression.encode()).hexdigest(), result)
 
     if not result:
         raise InvalidRSEExpression('RSE Expression resulted in an empty set.')


### PR DESCRIPTION
In m-VO mode tests that didn't specify an RSE expression would cache and retrieve a list of all RSEs at the VO, which didn't update between tests causing failures. Fixed by preventing caching if the RSE expression is only the VO.
