### PR TITLE
Multi-VO: enable consecutive test runs; Fix #30

### DIFF
--- a/lib/rucio/api/authentication.py
+++ b/lib/rucio/api/authentication.py
@@ -262,7 +262,8 @@ def validate_auth_token(token):
     """
 
     auth = authentication.validate_auth_token(token)
-    vo = auth['account'].vo
-    auth = api_update_return_dict(auth)
-    auth['vo'] = vo
+    if auth is not None:
+        vo = auth['account'].vo
+        auth = api_update_return_dict(auth)
+        auth['vo'] = vo
     return auth


### PR DESCRIPTION
Avoid trying to get the VO when `validate_auth_token` fails and returns None.