### PR TITLE
internal: Added more VO to c3po #16

### DIFF
--- a/lib/rucio/api/scope.py
+++ b/lib/rucio/api/scope.py
@@ -9,6 +9,7 @@
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2012
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2012
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -20,13 +21,20 @@ from rucio.common.types import InternalAccount, InternalScope
 from rucio.common.schema import validate_schema
 
 
-def list_scopes():
+def list_scopes(filter={}, vo='def'):
     """
     Lists all scopes.
 
+    :param filter: Dictionary of attributes by which the input data should be filtered
+    :param vo: The VO to act on.
+
     :returns: A list containing all scopes.
     """
-    return [scope.external for scope in core_scope.list_scopes()]
+    if 'scope' in filter:
+        filter['scope'] = InternalScope(scope=filter['scope'], vo=vo)
+    else:
+        filter['scope'] = InternalScope(scope='*', vo=vo)
+    return [scope.external for scope in core_scope.list_scopes(filter=filter)]
 
 
 def add_scope(scope, account, issuer, vo='def'):

--- a/lib/rucio/common/utils.py
+++ b/lib/rucio/common/utils.py
@@ -27,6 +27,7 @@
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
 # - Gabriele Fronze' <gfronze@cern.ch>, 2019
 # - Jaroslav Guenther <jaroslav.guenther@gmail.com>, 2019
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -1245,6 +1246,23 @@ def api_update_rse_expression(rse_expression):
             return rse_expression
     else:
         return rse_expression
+
+
+def add_vo_to_rse_expression(rse_expression, vo='def'):
+    """
+    Formats rse_expression to include the vo if it isn't 'def'
+
+    :param rse_expression: The RSE expression to edit
+    :param vo: The vo to add, optional, defaults to 'def'
+
+    :returns rse_expression: The edited rse_expression
+    """
+    if vo != 'def':
+        if rse_expression is not None:
+            rse_expression = 'vo={}&({})'.format(vo, rse_expression)
+        else:
+            rse_expression = 'vo={}'.format(vo)
+    return rse_expression
 
 
 def get_parsed_throttler_mode(throttler_mode):

--- a/lib/rucio/core/scope.py
+++ b/lib/rucio/core/scope.py
@@ -13,6 +13,7 @@
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2015
 # - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2019
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -78,16 +79,24 @@ def bulk_add_scopes(scopes, account, skipExisting=False, session=None):
 
 
 @read_session
-def list_scopes(session=None):
+def list_scopes(filter={}, session=None):
     """
     Lists all scopes.
-
+    :param filter: Dictionary of attributes by which the input data should be filtered
     :param session: The database session in use.
 
     :returns: A list containing all scopes.
     """
     scope_list = []
     query = session.query(models.Scope).filter(models.Scope.status != ScopeStatus.DELETED)
+    for filter_type in filter:
+        if filter_type == 'scope':
+            if '*' in filter['scope'].internal:
+                scope_str = filter['scope'].internal.replace('*', '%')
+                query = query.filter(models.Scope.scope.like(scope_str))
+            else:
+                query = query.filter_by(scope=filter['scope'])
+
     for s in query:
         scope_list.append(s.scope)
     return scope_list

--- a/lib/rucio/daemons/automatix/automatix.py
+++ b/lib/rucio/daemons/automatix/automatix.py
@@ -21,6 +21,7 @@
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -324,7 +325,8 @@ def run(total_workers=1, once=False, inputfile=None):
     try:
         scope = get('automatix', 'scope')
         client = Client()
-        if InternalScope(scope, vo=client.vo) not in list_scopes():
+        filters = {'scope': InternalScope('*', vo=client.vo)}
+        if InternalScope(scope, vo=client.vo) not in list_scopes(filter=filters):
             logging.error('Scope %s does not exist. Exiting', scope)
             GRACEFUL_STOP.set()
     except Exception:

--- a/lib/rucio/daemons/c3po/c3po.py
+++ b/lib/rucio/daemons/c3po/c3po.py
@@ -16,6 +16,7 @@
 # - Thomas Beermann <thomas.beermann@cern.ch>, 2015-2017
 # - Vincent Garonne <vgaronne@gmail.com>, 2017-2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2018-2019
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -45,6 +46,7 @@ from rucio.client import Client
 from rucio.common.config import config_get, config_get_options
 from rucio.common.exception import RucioException
 from rucio.common.types import InternalScope
+from rucio.common.utils import add_vo_to_rse_expression
 from rucio.daemons.c3po.collectors.free_space import FreeSpaceCollector
 from rucio.daemons.c3po.collectors.jedi_did import JediDIDCollector
 from rucio.daemons.c3po.collectors.workload import WorkloadCollector
@@ -166,6 +168,8 @@ def place_replica(once=False,
                 return
             client = Client(auth_type='x509_proxy', account='c3po', creds={'client_proxy': '/opt/rucio/etc/ddmadmin.long.proxy'})
 
+        vo = client.vo
+        dest_rse_expr = add_vo_to_rse_expression(dest_rse_expr, vo=vo)
         instances = {}
         for algorithm in algorithms:
             module_path = 'rucio.daemons.c3po.algorithms.' + algorithm
@@ -215,7 +219,7 @@ def place_replica(once=False,
             for _ in range(0, len_dids):
                 did = did_queue.get()
                 if isinstance(did[0], string_types):
-                    did[0] = InternalScope(did[0])
+                    did[0] = InternalScope(did[0], vo=vo)
                 for algorithm, instance in instances.items():
                     logging.info('(%s:%s) Retrieved %s:%s from queue. Run placement algorithm' % (algorithm, instance_id, did[0], did[1]))
                     decision = instance.place(did)

--- a/lib/rucio/tests/test_multi_vo.py
+++ b/lib/rucio/tests/test_multi_vo.py
@@ -15,12 +15,25 @@
 # Authors:
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_true, assert_false
+from random import choice
+from string import ascii_uppercase
 
-from rucio.common.config import config_get_bool
+from rucio.api.account import add_account, list_accounts
+from rucio.api.did import add_did, list_dids
+from rucio.api.rse import add_rse, list_rses
+from rucio.api.scope import add_scope, list_scopes
+from rucio.client.accountclient import AccountClient
 from rucio.client.client import Client
+from rucio.client.didclient import DIDClient
+from rucio.client.rseclient import RSEClient
 from rucio.client.replicaclient import ReplicaClient
+from rucio.client.scopeclient import ScopeClient
 from rucio.client.uploadclient import UploadClient
+from rucio.common.config import config_get_bool
+from rucio.common.exception import Duplicate
+from rucio.common.utils import generate_uuid
+from rucio.core.vo import add_vo
 
 
 class TestMultiVoClients(object):
@@ -28,8 +41,14 @@ class TestMultiVoClients(object):
     def setup(self):
         if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
             self.vo = {'vo': 'tst'}
+            self.new_vo = {'vo': 'new'}
+            try:
+                add_vo(description='Test', email='rucio@email.com', **self.new_vo)
+            except Duplicate:
+                print('VO "%s" already exists' % self.new_vo['vo'])
         else:
             self.vo = {}
+            self.new_vo = {}
 
     def test_get_vo_from_config(self):
         """ MULTI VO (CLIENT): Get vo from config file when starting clients """
@@ -37,7 +56,90 @@ class TestMultiVoClients(object):
         replica_client = ReplicaClient(vo=None)
         client = Client(vo=None)
         upload_client = UploadClient(_client=client)
-
         # Check the vo has been got from the config file
         assert_equal(replica_client.vo, self.vo['vo'])
         assert_equal(upload_client.client.vo, self.vo['vo'])
+
+    def test_accounts_at_different_vos(self):
+        """ MULTI VO (CLIENT): Test that accounts from 2nd vo don't interfere """
+        account_client = AccountClient()
+        usr_uuid = str(generate_uuid()).lower()[:16]
+        tst = 'tst-%s' % usr_uuid
+        new = 'new-%s' % usr_uuid
+        shr = 'shr-%s' % usr_uuid
+        account_client.add_account(tst, 'USER', 'rucio@email.com')
+        account_client.add_account(shr, 'USER', 'rucio@email.com')
+        add_account(new, 'USER', 'rucio@email.com', 'root', **self.new_vo)
+        add_account(shr, 'USER', 'rucio@email.com', 'root', **self.new_vo)
+        account_list_tst = [a['account'] for a in account_client.list_accounts()]
+        account_list_new = [a['account'] for a in list_accounts(filter={}, **self.new_vo)]
+        assert_true(tst in account_list_tst)
+        assert_false(new in account_list_tst)
+        assert_true(shr in account_list_tst)
+        assert_false(tst in account_list_new)
+        assert_true(new in account_list_new)
+        assert_true(shr in account_list_new)
+
+    def test_dids_at_different_vos(self):
+        """ MULTI VO (CLIENT): Test that dids from 2nd vo don't interfere """
+        scope_uuid = str(generate_uuid()).lower()[:16]
+        scope = 'shr_%s' % scope_uuid
+        add_scope(scope, 'root', 'root', **self.vo)
+        add_scope(scope, 'root', 'root', **self.new_vo)
+        did_client = DIDClient()
+        did_uuid = str(generate_uuid()).lower()[:16]
+        tst = 'tstset_%s' % did_uuid
+        new = 'newset_%s' % did_uuid
+        shr = 'shrset_%s' % did_uuid
+        did_client.add_did(scope, tst, 'DATASET')
+        did_client.add_did(scope, shr, 'DATASET')
+        add_did(scope, new, 'DATASET', 'root', **self.new_vo)
+        add_did(scope, shr, 'DATASET', 'root', **self.new_vo)
+        did_list_tst = [d for d in did_client.list_dids(scope, {})]
+        did_list_new = [d for d in list_dids(scope, {}, **self.new_vo)]
+        assert_true(tst in did_list_tst)
+        assert_false(new in did_list_tst)
+        assert_true(shr in did_list_tst)
+        assert_false(tst in did_list_new)
+        assert_true(new in did_list_new)
+        assert_true(shr in did_list_new)
+
+    def test_rses_at_different_vos(self):
+        """ MULTI VO (CLIENT): Test that RSEs from 2nd vo don't interfere """
+        rse_client = RSEClient()
+        rse_str = ''.join(choice(ascii_uppercase) for x in range(10))
+        tst = 'TST_%s' % rse_str
+        new = 'NEW_%s' % rse_str
+        shr = 'SHR_%s' % rse_str
+        rse_client.add_rse(tst)
+        rse_client.add_rse(shr)
+        add_rse(new, 'root', **self.new_vo)
+        add_rse(shr, 'root', **self.new_vo)
+        rse_list_tst = [r['rse'] for r in rse_client.list_rses()]
+        rse_list_new = [r['rse'] for r in list_rses(filters={}, **self.new_vo)]
+        assert_true(tst in rse_list_tst)
+        assert_false(new in rse_list_tst)
+        assert_true(shr in rse_list_tst)
+        assert_false(tst in rse_list_new)
+        assert_true(new in rse_list_new)
+        assert_true(shr in rse_list_new)
+
+    def test_scopes_at_different_vos(self):
+        """ MULTI VO (CLIENT): Test that scopes from 2nd vo don't interfere """
+        scope_client = ScopeClient()
+        scope_uuid = str(generate_uuid()).lower()[:16]
+        tst = 'tst_%s' % scope_uuid
+        new = 'new_%s' % scope_uuid
+        shr = 'shr_%s' % scope_uuid
+        scope_client.add_scope('root', tst)
+        scope_client.add_scope('root', shr)
+        add_scope(new, 'root', 'root', **self.new_vo)
+        add_scope(shr, 'root', 'root', **self.new_vo)
+        scope_list_tst = [s for s in scope_client.list_scopes()]
+        scope_list_new = [s for s in list_scopes(filter={}, **self.new_vo)]
+        assert_true(tst in scope_list_tst)
+        assert_false(new in scope_list_tst)
+        assert_true(shr in scope_list_tst)
+        assert_false(tst in scope_list_new)
+        assert_true(new in scope_list_new)
+        assert_true(shr in scope_list_new)

--- a/lib/rucio/tests/test_rse_expression_parser.py
+++ b/lib/rucio/tests/test_rse_expression_parser.py
@@ -9,6 +9,7 @@
 # - Martin Barisits, <martin.barisits@cern.ch>, 2013-2017
 # - Hannes Hansen, <hannes.jakob.hansen@cern.ch>, 2019
 # - Andrew Lister, <andrew.lister@stfc.ac.uk>, 2019
+# - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
 
 from random import choice
 from string import ascii_uppercase, digits, ascii_lowercase
@@ -16,6 +17,7 @@ from string import ascii_uppercase, digits, ascii_lowercase
 from nose.tools import assert_equal, raises, assert_raises
 
 from rucio.common.config import config_get_bool
+from rucio.common.utils import add_vo_to_rse_expression
 from rucio.core import rse
 from rucio.core import rse_expression_parser
 from rucio.client.rseclient import RSEClient
@@ -84,68 +86,84 @@ class TestRSEExpressionParserCore(object):
     @raises(InvalidRSEExpression)
     def test_unconnected_operator(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test invalid rse expression: unconnected operator"""
-        rse_expression_parser.parse_expression("TEST_RSE1|")
+        rse_expression = add_vo_to_rse_expression("TEST_RSE1|", **self.vo)
+        rse_expression_parser.parse_expression(rse_expression)
 
     @raises(InvalidRSEExpression)
     def test_wrong_parantheses(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test invalid rse expression: wrong parantheses """
-        rse_expression_parser.parse_expression("TEST_RSE1)")
+        rse_expression = add_vo_to_rse_expression("TEST_RSE1)", **self.vo)
+        rse_expression_parser.parse_expression(rse_expression)
 
     @raises(InvalidRSEExpression)
     def test_unknown_rse(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test unknown RSE """
-        rse_expression_parser.parse_expression("TEST_RSE999")
+        rse_expression = add_vo_to_rse_expression("TEST_RSE999", **self.vo)
+        rse_expression_parser.parse_expression(rse_expression)
 
     def test_simple_rse_reference(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test simple RSE reference """
-        assert_equal([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(self.rse1)], [self.rse1_id])
+        rse_expression = add_vo_to_rse_expression(self.rse1, **self.vo)
+        assert_equal([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)], [self.rse1_id])
 
     def test_attribute_reference(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test simple RSE attribute reference """
-        assert_equal([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("%s=uk" % self.attribute)], [self.rse4_id])
+        rse_expression = add_vo_to_rse_expression("%s=uk" % self.attribute, **self.vo)
+        assert_equal([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)], [self.rse4_id])
 
     def test_all_rse(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test reference on all RSE """
-        all_rses = rse.list_rses()
-        assert_equal(sorted(rse_expression_parser.parse_expression("*"), key=lambda rse: rse['rse']), sorted(all_rses, key=lambda rse: rse['rse']))
+        filters = self.vo
+        all_rses = rse.list_rses(filters)
+        rse_expression = add_vo_to_rse_expression("*", **self.vo)
+        assert_equal(sorted(rse_expression_parser.parse_expression(rse_expression), key=lambda rse: rse['rse']), sorted(all_rses, key=lambda rse: rse['rse']))
 
     def test_tag_reference(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test simple RSE tag reference """
-        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(self.tag1)]), sorted([self.rse1_id, self.rse2_id, self.rse3_id]))
+        rse_expression = add_vo_to_rse_expression(self.tag1, **self.vo)
+        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)]), sorted([self.rse1_id, self.rse2_id, self.rse3_id]))
 
     def test_parantheses(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test parantheses """
-        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("(%s)" % self.tag1)]), sorted([self.rse1_id, self.rse2_id, self.rse3_id]))
+        rse_expression = add_vo_to_rse_expression("(%s)" % self.tag1, **self.vo)
+        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)]), sorted([self.rse1_id, self.rse2_id, self.rse3_id]))
 
     def test_union(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test union operator """
-        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("%s|%s" % (self.tag1, self.tag2))]), sorted([self.rse1_id, self.rse2_id, self.rse3_id, self.rse4_id, self.rse5_id]))
+        rse_expression = add_vo_to_rse_expression("%s|%s" % (self.tag1, self.tag2), **self.vo)
+        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)]), sorted([self.rse1_id, self.rse2_id, self.rse3_id, self.rse4_id, self.rse5_id]))
 
     def test_complement(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test complement operator """
-        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("%s\\%s" % (self.tag1, self.rse3))]), sorted([self.rse1_id, self.rse2_id]))
+        rse_expression = add_vo_to_rse_expression("%s\\%s" % (self.tag1, self.rse3), **self.vo)
+        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)]), sorted([self.rse1_id, self.rse2_id]))
 
     def test_intersect(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test intersect operator """
-        assert_equal([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("%s&%s=uk" % (self.tag2, self.attribute))], [self.rse4_id])
+        rse_expression = add_vo_to_rse_expression("%s&%s=uk" % (self.tag2, self.attribute), **self.vo)
+        assert_equal([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)], [self.rse4_id])
 
     def test_order_of_operations(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test order of operations """
-        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("%s\\%s|%s=fr" % (self.tag1, self.rse3, self.attribute))]), sorted([self.rse1_id, self.rse2_id, self.rse3_id]))
-        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("%s\\(%s|%s=fr)" % (self.tag1, self.rse3, self.attribute))]), sorted([self.rse1_id, self.rse2_id]))
+        rse_expression = add_vo_to_rse_expression("%s\\%s|%s=fr" % (self.tag1, self.rse3, self.attribute), **self.vo)
+        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)]), sorted([self.rse1_id, self.rse2_id, self.rse3_id]))
+        rse_expression = add_vo_to_rse_expression("%s\\(%s|%s=fr)" % (self.tag1, self.rse3, self.attribute), **self.vo)
+        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)]), sorted([self.rse1_id, self.rse2_id]))
 
     def test_complicated_expression_1(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test some complicated expression 1"""
-        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("(%s|%s)\\%s|%s&%s" % (self.tag1, self.tag2, self.tag2, self.tag2, self.tag1))]), sorted([self.rse1_id, self.rse2_id, self.rse3_id]))
+        rse_expression = add_vo_to_rse_expression("(%s|%s)\\%s|%s&%s" % (self.tag1, self.tag2, self.tag2, self.tag2, self.tag1), **self.vo)
+        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)]), sorted([self.rse1_id, self.rse2_id, self.rse3_id]))
 
     def test_complicated_expression_2(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test some complicated expression 2"""
-        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("(((((%s))))|%s=us)&%s|(%s=at|%s=de)" %
-                                                                                             (self.tag1, self.attribute, self.tag2, self.attribute, self.attribute))]), sorted([self.rse1_id, self.rse2_id, self.rse5_id]))
+        rse_expression = add_vo_to_rse_expression("(((((%s))))|%s=us)&%s|(%s=at|%s=de)" % (self.tag1, self.attribute, self.tag2, self.attribute, self.attribute), **self.vo)
+        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)]), sorted([self.rse1_id, self.rse2_id, self.rse5_id]))
 
     def test_complicated_expression_3(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test some complicated expression 3"""
-        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("(*)&%s=at" % self.attribute)]), sorted([self.rse1_id]))
+        rse_expression = add_vo_to_rse_expression("(*)&%s=at" % self.attribute, **self.vo)
+        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)]), sorted([self.rse1_id]))
 
     def test_list_on_availability(self):
         """ RSE_EXPRESSION_PARSER (CORE) List rses based on availability filter"""
@@ -163,22 +181,29 @@ class TestRSEExpressionParserCore(object):
         rse.update_rse(rsewrite_id, {'availability_write': True})
         rse.update_rse(rsenowrite_id, {'availability_write': False})
 
-        assert_equal(sorted([item['id'] for item in rse_expression_parser.parse_expression("%s=de" % attribute)]),
+        rse_expression = add_vo_to_rse_expression("%s=de" % attribute, **self.vo)
+        assert_equal(sorted([item['id'] for item in rse_expression_parser.parse_expression(rse_expression)]),
                      sorted([rsewrite_id, rsenowrite_id]))
 
-        assert_equal(sorted([item['id'] for item in rse_expression_parser.parse_expression("%s=de" % attribute, {'availability_write': True})]),
+        assert_equal(sorted([item['id'] for item in rse_expression_parser.parse_expression(rse_expression, {'availability_write': True})]),
                      sorted([rsewrite_id]))
 
-        assert_raises(RSEBlacklisted, rse_expression_parser.parse_expression, "%s=de" % attribute, {'availability_write': False})
+        assert_raises(RSEBlacklisted, rse_expression_parser.parse_expression, rse_expression, {'availability_write': False})
 
     def test_numeric_operators(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test RSE attributes with numeric operations """
-        assert_equal([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("%s<11" % self.attribute_numeric)], [self.rse1_id])
-        assert_raises(InvalidRSEExpression, rse_expression_parser.parse_expression, "%s<9" % self.attribute_numeric)
-        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("%s<21" % self.attribute_numeric)]), sorted([self.rse1_id, self.rse2_id]))
-        assert_equal([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("%s>49" % self.attribute_numeric)], [self.rse5_id])
-        assert_raises(InvalidRSEExpression, rse_expression_parser.parse_expression, "%s>51" % self.attribute_numeric)
-        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression("%s>30" % self.attribute_numeric)]), sorted([self.rse4_id, self.rse5_id]))
+        rse_expression = add_vo_to_rse_expression("%s<11" % self.attribute_numeric, **self.vo)
+        assert_equal([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)], [self.rse1_id])
+        rse_expression = add_vo_to_rse_expression("%s<9" % self.attribute_numeric, **self.vo)
+        assert_raises(InvalidRSEExpression, rse_expression_parser.parse_expression, rse_expression)
+        rse_expression = add_vo_to_rse_expression("%s<21" % self.attribute_numeric, **self.vo)
+        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)]), sorted([self.rse1_id, self.rse2_id]))
+        rse_expression = add_vo_to_rse_expression("%s>49" % self.attribute_numeric, **self.vo)
+        assert_equal([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)], [self.rse5_id])
+        rse_expression = add_vo_to_rse_expression("%s>51" % self.attribute_numeric, **self.vo)
+        assert_raises(InvalidRSEExpression, rse_expression_parser.parse_expression, rse_expression)
+        rse_expression = add_vo_to_rse_expression("%s>30" % self.attribute_numeric, **self.vo)
+        assert_equal(sorted([t_rse['id'] for t_rse in rse_expression_parser.parse_expression(rse_expression)]), sorted([self.rse4_id, self.rse5_id]))
 
 
 class TestRSEExpressionParserClient(object):
@@ -223,10 +248,12 @@ class TestRSEExpressionParserClient(object):
 
     def test_complicated_expression(self):
         """ RSE_EXPRESSION_PARSER (CLIENT) Test some complicated expression"""
-        rses = [item['rse'] for item in self.rse_client.list_rses("(((((%s))))|%s=us)&%s|(%s=at|%s=de)" % (self.tag1, self.attribute, self.tag2, self.attribute, self.attribute))]
+        rse_expression = add_vo_to_rse_expression("(((((%s))))|%s=us)&%s|(%s=at|%s=de)" % (self.tag1, self.attribute, self.tag2, self.attribute, self.attribute), **self.vo)
+        rses = [item['rse'] for item in self.rse_client.list_rses(rse_expression)]
         assert_equal(sorted(rses), sorted([self.rse1, self.rse2, self.rse5]))
 
     def test_complicated_expression_1(self):
         """ RSE_EXPRESSION_PARSER (CORE) Test some complicated expression 1"""
-        rses = [item['rse'] for item in self.rse_client.list_rses("(%s|%s)\\%s|%s&%s" % (self.tag1, self.tag2, self.tag2, self.tag2, self.tag1))]
+        rse_expression = add_vo_to_rse_expression("(%s|%s)\\%s|%s&%s" % (self.tag1, self.tag2, self.tag2, self.tag2, self.tag1), **self.vo)
+        rses = [item['rse'] for item in self.rse_client.list_rses(rse_expression)]
         assert_equal(sorted(rses), sorted([self.rse1, self.rse2, self.rse3]))

--- a/lib/rucio/web/rest/flaskapi/v1/scope.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scope.py
@@ -19,6 +19,7 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -63,7 +64,7 @@ class Scope(MethodView):
         :status 406: Not Acceptable
         :returns: :class:`String`
         """
-        return dumps(list_scopes())
+        return dumps(list_scopes(vo=request.environ.get('vo')))
 
     def post(self, account, scope):
         """Add a new scope.

--- a/lib/rucio/web/rest/flaskapi/v1/scope.py
+++ b/lib/rucio/web/rest/flaskapi/v1/scope.py
@@ -64,7 +64,7 @@ class Scope(MethodView):
         :status 406: Not Acceptable
         :returns: :class:`String`
         """
-        return dumps(list_scopes(vo=request.environ.get('vo')))
+        return dumps(list_scopes(filter={}, vo=request.environ.get('vo')))
 
     def post(self, account, scope):
         """Add a new scope.

--- a/lib/rucio/web/rest/webpy/v1/scope.py
+++ b/lib/rucio/web/rest/webpy/v1/scope.py
@@ -19,6 +19,7 @@
 # - Mario Lassnig <mario.lassnig@cern.ch>, 2018
 # - Hannes Hansen <hannes.jakob.hansen@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Patrick Austin, <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -58,7 +59,7 @@ class Scope(RucioController):
         HTTP Error:
             406 Not Acceptable
         """
-        return dumps(list_scopes())
+        return dumps(list_scopes(vo=ctx.env.get('vo')))
 
     def POST(self, account, scope):
         """

--- a/lib/rucio/web/rest/webpy/v1/scope.py
+++ b/lib/rucio/web/rest/webpy/v1/scope.py
@@ -59,7 +59,7 @@ class Scope(RucioController):
         HTTP Error:
             406 Not Acceptable
         """
-        return dumps(list_scopes(vo=ctx.env.get('vo')))
+        return dumps(list_scopes(filter={}, vo=ctx.env.get('vo')))
 
     def POST(self, account, scope):
         """


### PR DESCRIPTION
internal: Added more VO to c3po #16
------------------

It turns out a lot of the work for this was already done by Andrew after all, for example changing the algorithms to use RSE ids rather than names.

That being said, there were a couple of things that needed updating, namely adding VO to the RSE expression (happens in `c3po` but should affect all algorithms) and to the `InternalScope`. The VO was obtained from the client that gets started by the daemon. The `simple` algorithm still uses RSE names rather than ids, but this doesn't call into core so I think it's OK as it is.

Can't see any existing tests for c3po, so can't verify if this is working as intended.
