### PR TITLE
internal user-interaction: Add update, recovery for VOs, plus tests #17

### DIFF
--- a/lib/rucio/core/permission/atlas.py
+++ b/lib/rucio/core/permission/atlas.py
@@ -21,6 +21,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -117,7 +118,10 @@ def has_permission(issuer, action, kwargs):
             'del_identity': perm_del_identity,
             'remove_did_from_followed': perm_remove_did_from_followed,
             'remove_dids_from_followed': perm_remove_dids_from_followed,
-            'add_vo': perm_add_vo}
+            'add_vo': perm_add_vo,
+            'list_vos': perm_list_vos,
+            'recover_vo_root_identity': perm_recover_vo_root_identity,
+            'update_vo': perm_update_vo}
 
     return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs)
 
@@ -1147,6 +1151,39 @@ def perm_remove_dids_from_followed(issuer, kwargs):
 def perm_add_vo(issuer, kwargs):
     """
     Checks if an account can add a VO.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :returns: True if account is allowed, otherwise False
+    """
+    return (issuer.internal == 'super_root')
+
+
+def perm_list_vos(issuer, kwargs):
+    """
+    Checks if an account can list a VO.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :returns: True if account is allowed, otherwise False
+    """
+    return (issuer.internal == 'super_root')
+
+
+def perm_recover_vo_root_identity(issuer, kwargs):
+    """
+    Checks if an account can recover identities for VOs.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :returns: True if account is allowed, otherwise False
+    """
+    return (issuer.internal == 'super_root')
+
+
+def perm_update_vo(issuer, kwargs):
+    """
+    Checks if an account can update a VO.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/core/permission/generic.py
+++ b/lib/rucio/core/permission/generic.py
@@ -21,6 +21,7 @@
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Ruturaj Gujar <ruturaj.gujar23@gmail.com>, 2019
 # - Eli Chadwick <eli.chadwick@stfc.ac.uk>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -116,7 +117,10 @@ def has_permission(issuer, action, kwargs):
             'del_identity': perm_del_identity,
             'remove_did_from_followed': perm_remove_did_from_followed,
             'remove_dids_from_followed': perm_remove_dids_from_followed,
-            'add_vo': perm_add_vo}
+            'add_vo': perm_add_vo,
+            'list_vos': perm_list_vos,
+            'recover_vo_root_identity': perm_recover_vo_root_identity,
+            'update_vo': perm_update_vo}
 
     return perm.get(action, perm_default)(issuer=issuer, kwargs=kwargs)
 
@@ -970,6 +974,39 @@ def perm_remove_dids_from_followed(issuer, kwargs):
 def perm_add_vo(issuer, kwargs):
     """
     Checks if an account can add a VO.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :returns: True if account is allowed, otherwise False
+    """
+    return (issuer.internal == 'super_root')
+
+
+def perm_list_vos(issuer, kwargs):
+    """
+    Checks if an account can list a VO.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :returns: True if account is allowed, otherwise False
+    """
+    return (issuer.internal == 'super_root')
+
+
+def perm_recover_vo_root_identity(issuer, kwargs):
+    """
+    Checks if an account can recover identities for VOs.
+
+    :param issuer: Account identifier which issues the command.
+    :param kwargs: List of arguments for the action.
+    :returns: True if account is allowed, otherwise False
+    """
+    return (issuer.internal == 'super_root')
+
+
+def perm_update_vo(issuer, kwargs):
+    """
+    Checks if an account can update a VO.
 
     :param issuer: Account identifier which issues the command.
     :param kwargs: List of arguments for the action.

--- a/lib/rucio/core/vo.py
+++ b/lib/rucio/core/vo.py
@@ -14,8 +14,10 @@
 #
 # Authors:
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 
 from sqlalchemy.exc import DatabaseError, IntegrityError
+from sqlalchemy.orm.exc import NoResultFound
 
 from rucio.common import exception
 from rucio.common.types import InternalAccount
@@ -98,3 +100,23 @@ def list_vos(session=None):
         vos.append(vo_dict)
 
     return vos
+
+
+@transactional_session
+def update_vo(vo, parameters, session=None):
+    """
+    Update VO properties (email, description).
+
+    :param vo: The VO to update.
+    :param parameters: A dictionary with the new properties.
+    :param session: The db session in use.
+    """
+    try:
+        query = session.query(models.VO).filter_by(vo=vo).one()
+    except NoResultFound:
+        raise exception.VONotFound('VO {} not found'.format(vo))
+    param = {}
+    for key in parameters:
+        if key in ['email', 'description']:
+            param[key] = parameters[key]
+    query.update(param)

--- a/lib/rucio/tests/test_multi_vo.py
+++ b/lib/rucio/tests/test_multi_vo.py
@@ -15,12 +15,61 @@
 # Authors:
 # - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_in, assert_raises, assert_true
 
+from rucio.api import vo as vo_api
+from rucio.api.identity import list_accounts_for_identity
 from rucio.common.config import config_get_bool
 from rucio.client.client import Client
 from rucio.client.replicaclient import ReplicaClient
 from rucio.client.uploadclient import UploadClient
+from rucio.common.exception import AccessDenied, Duplicate
+from rucio.common.utils import generate_uuid
+
+
+class TestVOCoreAPI(object):
+
+    def setup(self):
+        if config_get_bool('common', 'multi_vo', raise_exception=False, default=False):
+            self.vo = {'vo': 'tst'}
+            self.new_vo = generate_uuid()[:3]
+        else:
+            self.vo = {}
+
+    def test_add_vo(self):
+        """ MULTI VO (CORE): Test creation of VOs """
+        with assert_raises(AccessDenied):
+            vo_api.add_vo(self.new_vo, 'root', 'Add new VO with root', 'rucio@email.com', **self.vo)
+        vo_api.add_vo(self.new_vo, 'super_root', 'Add new VO with super_root', 'rucio@email.com', 'def')
+        with assert_raises(Duplicate):
+            vo_api.add_vo(self.new_vo, 'super_root', 'Add existing VO', 'rucio@email.com', 'def')
+        vo_list = [v['vo'] for v in vo_api.list_vos('super_root', 'def')]
+        assert_in(self.new_vo, vo_list)
+
+    def test_recover_root_identity(self):
+        """ MULTI VO (CORE): Test adding a new identity for root using super_root """
+        vo_api.add_vo(self.new_vo, 'super_root', 'Add new VO with super_root', 'rucio@email.com', 'def')
+        with assert_raises(AccessDenied):
+            vo_api.recover_vo_root_identity(root_vo=self.new_vo, identity_key='recovered@%s' % self.new_vo, id_type='userpass',
+                                            email='rucio@email.com', issuer='root', password='password', vo=self.new_vo)
+        vo_api.recover_vo_root_identity(root_vo=self.new_vo, identity_key='recovered@%s' % self.new_vo, id_type='userpass',
+                                        email='rucio@email.com', issuer='super_root', password='password', vo='def')
+        assert_in('root', list_accounts_for_identity(identity_key='recovered@%s' % self.new_vo, id_type='userpass'))
+
+    def test_update_vo(self):
+        """ MULTI VO (CORE): Test updating VOs """
+        vo_api.add_vo(self.new_vo, 'super_root', 'Add new VO with super_root', 'rucio@email.com', 'def')
+        parameters = {'vo': self.new_vo, 'description': 'Updated description', 'email': 'updated@email.com'}
+        with assert_raises(AccessDenied):
+            vo_api.update_vo(self.new_vo, parameters, 'root', **self.vo)
+        vo_api.update_vo(self.new_vo, parameters, 'super_root', 'def')
+        vo_update_success = False
+        for v in vo_api.list_vos('super_root', 'def'):
+            if v['vo'] == parameters['vo']:
+                assert_equal(parameters['email'], v['email'])
+                assert_equal(parameters['description'], v['description'])
+                vo_update_success = True
+        assert_true(vo_update_success)
 
 
 class TestMultiVoClients(object):


### PR DESCRIPTION
internal user-interaction: Add update, recovery for VOs, plus tests #17
------------------

Added the `update_vo` and `recover_vo_root_identity` at API and core levels. Have also added permissions for these functions to `generic` and `atlas`. Have added tests to `test_multi_vo` for these new functions, and for the pre-existing `add_vo`.
