### PR TITLE
internal user-interaction: Automatix test handles single file injections #25

### DIFF
--- a/lib/rucio/rse/rsemanager.py
+++ b/lib/rucio/rse/rsemanager.py
@@ -29,6 +29,7 @@
 # - Gabriele Fronze' <gfronze@cern.ch>, 2019
 # - Andrew Lister <andrew.lister@stfc.ac.uk>, 2019
 # - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2020
+# - Patrick Austin <patrick.austin@stfc.ac.uk>, 2020
 #
 # PY3K COMPATIBLE
 
@@ -484,8 +485,7 @@ def upload(rse_settings, lfns, domain='wan', source_dir=None, force_pfn=None, fo
             if isinstance(ret[x], Exception):
                 raise ret[x]
             else:
-                return {'success': ret[x],
-                        'pfn': pfn}
+                return {0: ret[x], 1: ret, 'success': ret[x], 'pfn': pfn}
     return {0: gs, 1: ret, 'success': gs, 'pfn': pfn}
 
 


### PR DESCRIPTION
Automatix test handles single file injections
------------------
Due to different formatting in the return of `rsemanager.upload`, automatix couldn't handle single files being added. The number of files is randomly chosen, and by default has a 1/4 chance of being 1. As a result this was causing intermittent test failures.

Changed the return of `rsemanager.upload` to be consistent between 1 and many file cases. 
